### PR TITLE
Add primary A/AAAA records

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,10 +1,11 @@
 resource "aws_cloudfront_distribution" "web_distribution" {
   enabled = true
-  comment = "${var.subdomain}.intimitrons.ca"
 
   is_ipv6_enabled = true
   http_version    = "http2"
   price_class     = "PriceClass_100"
+
+  aliases = ["${var.subdomain}.intimitrons.ca."]
 
   viewer_certificate {
     cloudfront_default_certificate = true

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,16 @@
+resource "aws_route53_record" "website_primary" {
+  for_each = {
+    v4 = "A"
+    v6 = "AAAA"
+  }
+
+  zone_id = data.terraform_remote_state.dns.outputs.zone_id
+  name    = var.subdomain
+  type    = each.value
+
+  alias {
+    name                   = aws_cloudfront_distribution.web_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.web_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "web_bucket" {
-  bucket = "trons-website-web-${var.subdomain}"
+  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI
+  bucket = "trons-website-web-${replace(var.subdomain, ".", "-")}"
   website {
     index_document = "index.html"
     error_document = "404.html"


### PR DESCRIPTION
Resolves #8 

- Modified S3 bucket naming in case the subdomain contains dots
- Remove `comment` from CF distribution, it is redundant in the console because the aliases and origin are shown