### PR TITLE
Remove trailing dot from CloudFront alias

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,7 +1,7 @@
 resource "aws_acm_certificate" "website_primary_certificate" {
   provider = aws.us-east-1
 
-  domain_name       = "${var.subdomain}.intimitrons.ca."
+  domain_name       = "${var.subdomain}.intimitrons.ca"
   validation_method = "DNS"
 }
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -5,7 +5,7 @@ resource "aws_cloudfront_distribution" "web_distribution" {
   http_version    = "http2"
   price_class     = "PriceClass_100"
 
-  aliases = ["${var.subdomain}.intimitrons.ca."]
+  aliases = ["${var.subdomain}.intimitrons.ca"]
 
   viewer_certificate {
     acm_certificate_arn      = aws_acm_certificate.website_primary_certificate.arn


### PR DESCRIPTION
It looks like the AWS provider (and the AWS API) would use a single UpdateDistribution call, so the certificate and alias should be updated at the same time. If you type the domain with the trailing dot in the console you get an error - perhaps this kind of validation is missing in the API.

The certificate does not show a trailing dot in the console or crt.sh (https://crt.sh/?id=2733193062)

This is intended to resolve the following error
```
InvalidViewerCertificate: The certificate that is attached to your distribution doesn't cover the alternate domain name (CNAME) that you're trying to add. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements
```