### PR TITLE
Create www DNS record

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -14,3 +14,15 @@ resource "aws_route53_record" "website_primary" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "website_redirect" {
+  zone_id = data.terraform_remote_state.dns.outputs.zone_id
+  name    = "www.${var.subdomain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_s3_bucket.redirect_bucket.website_domain
+    zone_id                = aws_s3_bucket.redirect_bucket.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/s3.tf
+++ b/s3.tf
@@ -46,8 +46,9 @@ resource "aws_s3_bucket_policy" "web_bucket_policy" {
 }
 
 resource "aws_s3_bucket" "redirect_bucket" {
+  // The bucket name must exactly match the DNS name
   // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
-  bucket = "trons-website-redirect-${replace(var.subdomain, ".", "-")}"
+  bucket = "www.${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
   website {
     redirect_all_requests_to = "https://${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
   }


### PR DESCRIPTION
Resolves #9

Unfortunately now the redirect and primary bucket have different naming conventions. The primary bucket was not renamed because of the SSL certificate implications which also affects any REST API calls to work with the bucket. Since the redirect bucket will never have files it is less of a concern that the certificate won't match. All buckets created after September 2020 will only support the virtual-hosted style URI.