### PR TITLE
Enable S3 access logging

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,14 +1,22 @@
 resource "aws_s3_bucket" "web_bucket" {
   // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
   bucket = "trons-website-web-${replace(var.subdomain, ".", "-")}"
+
   website {
     index_document = "index.html"
     error_document = "404.html"
   }
+
   lifecycle_rule {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 1
   }
+
+  logging {
+    target_bucket = aws_s3_bucket.log_bucket.id
+    target_prefix = "s3/web/"
+  }
+
   tags = {
     "trons:environment" = var.environment
     "trons:service"     = "website"
@@ -49,9 +57,16 @@ resource "aws_s3_bucket" "redirect_bucket" {
   // The bucket name must exactly match the DNS name
   // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
   bucket = "www.${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
+
   website {
     redirect_all_requests_to = "https://${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
   }
+
+  logging {
+    target_bucket = aws_s3_bucket.log_bucket.id
+    target_prefix = "s3/redirect/"
+  }
+
   tags = {
     "trons:environment" = var.environment
     "trons:service"     = "website"
@@ -76,4 +91,29 @@ data "aws_iam_policy_document" "deny_put_bucket_policy" {
 resource "aws_s3_bucket_policy" "redirect_bucket_policy" {
   bucket = aws_s3_bucket.redirect_bucket.id
   policy = data.aws_iam_policy_document.deny_put_bucket_policy.json
+}
+
+resource "aws_s3_bucket" "log_bucket" {
+  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
+  bucket = "trons-website-log-${replace(var.subdomain, ".", "-")}"
+  acl    = "log-delivery-write"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    enabled                                = true
+    abort_incomplete_multipart_upload_days = 1
+  }
+
+  tags = {
+    "trons:environment" = var.environment
+    "trons:service"     = "website"
+    "trons:terraform"   = "true"
+  }
 }


### PR DESCRIPTION
See #25 

This is a first step to
- Create log bucket
- Turn on S3 access logging

Will verify things like
- Log files produced
- Whether prefixes are appropriate
- Whether we can block unencrypted requests (likely no, how would log delivery know we want default encryption

Later will
- Turn on CloudFront logging
  - It may conflict with the canned ACL and cause state divergence (need to test)