### PR TITLE
Enable CloudFront logs

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -58,6 +58,11 @@ resource "aws_cloudfront_distribution" "web_distribution" {
     }
   }
 
+  logging_config {
+    bucket = aws_s3_bucket.log_bucket.bucket_regional_domain_name
+    prefix = "cloudFront/"
+  }
+
   tags = {
     "trons:environment" = var.environment
     "trons:service"     = "website"


### PR DESCRIPTION
See #25 

This intentionally doesn't set the ACL on the log bucket to see if it will diverge because of CloudFront adding it automatically.