### PR TITLE
Remove permissions used by gatsby-plugin-s3

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -12,8 +12,6 @@ data "aws_iam_policy_document" "deploy_policy" {
   statement {
     effect = "Allow"
     actions = [
-      // gatsby-plugin-s3 makes a GetBucketLocation call to get the bucket region and check the bucket exists
-      "s3:GetBucketLocation",
       "s3:ListBucket",
     ]
     resources = [aws_s3_bucket.web_bucket.arn]


### PR DESCRIPTION
See https://github.com/intimitrons4604/website/issues/65

With the new custom deploy tooling this action no longer needs to be allowed