### PR TITLE
Create DynamoDB table for deployment locks

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,0 +1,20 @@
+resource "aws_dynamodb_table" "lock_table" {
+  name = "trons-website-lock-${var.subdomain}"
+
+  // Only provisioned tables are included in the free tier
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 1
+  write_capacity = 1
+
+  hash_key = "id"
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = {
+    "trons:environment" = var.environment
+    "trons:service"     = "website"
+    "trons:terraform"   = "true"
+  }
+}


### PR DESCRIPTION
See https://github.com/intimitrons4604/website/issues/65

- Create the table used for locking
  - AWS free tier includes 25 _provisioned_ RCU and 25 _provisioned_ WCU per month. Since we currently have no other need for DynamoDB, provision the minimum capacity to use it for free rather than the small cost of per-request pricing. The free capacity should cover our needs in all environments.