### PR TITLE
Increase CloudFront default TTL

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "web_distribution" {
     compress         = false
     smooth_streaming = false
 
-    default_ttl = 60
+    default_ttl = 86400
     min_ttl     = 0
     max_ttl     = 31536000
 


### PR DESCRIPTION
Closes https://github.com/intimitrons4604/website/issues/12

- Explicitly use the default CloudFront TTL (24 hours)