### PR TITLE
Enable CloudFront GZIP compression

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -43,7 +43,7 @@ resource "aws_cloudfront_distribution" "web_distribution" {
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
 
-    compress         = false
+    compress         = true
     smooth_streaming = false
 
     default_ttl = 86400


### PR DESCRIPTION
Closes https://github.com/intimitrons4604/website/issues/80

Need to invalidate CloudFront after deploying.