### PR TITLE
Test S3 permanent divergence

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "2.64.0"
   region  = "us-west-2"
 }
 


### PR DESCRIPTION
Ever since changes from https://github.com/intimitrons4604/terraform-website/issues/25 the plan always shows the lifecycle rule changing.

Checking to see if this was caused by https://github.com/terraform-providers/terraform-provider-aws/commit/485838521b5df9f43cce01be4d17232c58449331 in provider v2.65.0