### PR TITLE
Make dummy change to test AWS provider

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -21,6 +21,7 @@ resource "aws_s3_bucket" "web_bucket" {
     "trons:environment" = var.environment
     "trons:service"     = "website"
     "trons:terraform"   = "true"
+    "tf-test"           = "tf-test"
   }
 }
 


### PR DESCRIPTION
Ever since changes from https://github.com/intimitrons4604/terraform-website/issues/25 the plan always shows the lifecycle rule changing.

Checking to see if this was caused by https://github.com/terraform-providers/terraform-provider-aws/commit/485838521b5df9f43cce01be4d17232c58449331 in provider v2.65.0

After https://github.com/intimitrons4604/terraform-website/pull/35 there are no differences being output in the plan, presumably because the offending provider code is only run when updating. Make a dummy change to try and see if the state diverges again.