### PR TITLE
Attempt to work around provider bug with S3 lifecycle

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -10,6 +10,12 @@ resource "aws_s3_bucket" "web_bucket" {
   lifecycle_rule {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 1
+
+    // This is here to work around a bug in the AWS provider
+    expiration {
+      expired_object_delete_marker = false
+      days                         = 0
+    }
   }
 
   logging {
@@ -21,7 +27,6 @@ resource "aws_s3_bucket" "web_bucket" {
     "trons:environment" = var.environment
     "trons:service"     = "website"
     "trons:terraform"   = "true"
-    "tf-test"           = "tf-test"
   }
 }
 
@@ -110,6 +115,12 @@ resource "aws_s3_bucket" "log_bucket" {
   lifecycle_rule {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 1
+
+    // This is here to work around a bug in the AWS provider
+    expiration {
+      expired_object_delete_marker = false
+      days                         = 0
+    }
   }
 
   tags = {


### PR DESCRIPTION
Ever since changes from https://github.com/intimitrons4604/terraform-website/issues/25 the plan always shows the lifecycle rule changing.

Checking to see if this was caused by https://github.com/terraform-providers/terraform-provider-aws/commit/485838521b5df9f43cce01be4d17232c58449331 in provider v2.65.0

After https://github.com/intimitrons4604/terraform-website/pull/36 the plan is back to showing differences. Explicitly add the dummy expiration that the provider is adding to rules to see if the issue goes away. Also remove dummy change.