### PR TITLE
Allow certificate replacement while in use

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,6 +1,10 @@
 resource "aws_acm_certificate" "website_primary_certificate" {
   provider = aws.us-east-1
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   domain_name       = "www.${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
   validation_method = "DNS"
 


### PR DESCRIPTION
Continuation of #44 

You can't destroy the certificate while it is in use by CloudFront

See https://github.com/intimitrons4604/website/issues/77