### PR TITLE
Output ARNs, add deploy policy output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,24 @@
-output "web_bucket_name" {
-  value       = aws_s3_bucket.web_bucket.id
-  description = "The name of the S3 bucket for website content"
+output "deploy_policy_arn" {
+  value       = aws_iam_policy.deploy_policy.arn
+  description = "The ARN of the IAM policy permitting deployment of the website"
 }
 
-output "web_distribution_id" {
-  value       = aws_cloudfront_distribution.web_distribution.id
-  description = "The ID of the CloudFront distribution for the website"
+output "lock_table_arn" {
+  value       = aws_dynamodb_table.lock_table.arn
+  description = "The ARN of the DynamoDB table for locks"
 }
 
-output "lock_table_name" {
-  value       = aws_dynamodb_table.lock_table.id
-  description = "The name of the DynamoDB table for locks"
+output "log_bucket_arn" {
+  value       = aws_s3_bucket.log_bucket.arn
+  description = "The ARN of the S3 bucket for access logs"
 }
 
-output "log_bucket_name" {
-  value       = aws_s3_bucket.log_bucket.id
-  description = "The name of the S3 bucket for access logs"
+output "web_bucket_arn" {
+  value       = aws_s3_bucket.web_bucket.arn
+  description = "The ARN of the S3 bucket for website content"
+}
+
+output "web_distribution_arn" {
+  value       = aws_cloudfront_distribution.web_distribution.arn
+  description = "The ARN of the CloudFront distribution for the website"
 }


### PR DESCRIPTION
Resolves #31

Use ARNs because they are unambiguous and contain the name/id/etc. depending on resource type