### PR TITLE
Add DNS variables for migration

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -1,12 +1,14 @@
 resource "aws_route53_record" "website_primary" {
-  for_each = {
+  for_each = var.manage_dns ? {
     v4 = "A"
     v6 = "AAAA"
-  }
+  } : {}
 
   zone_id = data.terraform_remote_state.dns.outputs.zone_id
   name    = "www.${var.subdomain}"
   type    = each.value
+
+  allow_overwrite = var.allow_dns_overwrite
 
   alias {
     name                   = aws_cloudfront_distribution.web_distribution.domain_name
@@ -16,9 +18,13 @@ resource "aws_route53_record" "website_primary" {
 }
 
 resource "aws_route53_record" "website_redirect" {
+  count = var.manage_dns ? 1 : 0
+
   zone_id = data.terraform_remote_state.dns.outputs.zone_id
   name    = var.subdomain
   type    = "A"
+
+  allow_overwrite = var.allow_dns_overwrite
 
   alias {
     name                   = aws_s3_bucket.redirect_bucket.website_domain

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,15 @@ variable "environment" {
   type        = string
   description = "The environment for created resources"
 }
+
+variable "manage_dns" {
+  type        = bool
+  description = "True to manage website DNS records (default), false otherwise"
+  default     = true
+}
+
+variable "allow_dns_overwrite" {
+  type        = bool
+  description = "True to allow existing DNS records to be overwritten, false otherwise (default)"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,5 +17,5 @@ variable "manage_dns" {
 variable "allow_dns_overwrite" {
   type        = bool
   description = "True to allow existing DNS records to be overwritten, false otherwise (default)"
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
See https://github.com/intimitrons4604/website/issues/108

- `manage_dns` is to allow deploying before cutting over
- `allow_dns_overwrite` is to allow update of existing records rather than having to destroy them or import them into the state. Normally we should use import here, but you can't import records at the apex (i.e. intimitrons.ca) due to a bug in Terraform, so just overwrite all of them.