### PR TITLE
Support empty subdomain at apex

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -5,7 +5,7 @@ resource "aws_acm_certificate" "website_primary_certificate" {
     create_before_destroy = true
   }
 
-  domain_name       = "www.${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
+  domain_name       = join(".", compact(["www", var.subdomain, trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")]))
   validation_method = "DNS"
 
   tags = {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -5,7 +5,7 @@ resource "aws_cloudfront_distribution" "web_distribution" {
   http_version    = "http2"
   price_class     = "PriceClass_100"
 
-  aliases = ["www.${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"]
+  aliases = [join(".", compact(["www", var.subdomain, trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")]))]
 
   viewer_certificate {
     acm_certificate_arn      = aws_acm_certificate.website_primary_certificate.arn

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "lock_table" {
-  name = "trons-website-lock-${var.subdomain}"
+  name = join("-", compact(["trons-website-lock", var.subdomain]))
 
   // Only provisioned tables are included in the free tier
   billing_mode   = "PROVISIONED"

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_user" "deploy_user" {
-  name = "svc_website-deploy-${var.subdomain}"
+  name = join("-", compact(["svc_website-deploy", var.subdomain]))
   tags = {
     "trons:environment" = var.environment
     "trons:service"     = "website"
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "deploy_policy" {
 }
 
 resource "aws_iam_policy" "deploy_policy" {
-  name   = "svc_website-deploy-${var.subdomain}"
+  name   = join("-", compact(["svc_website-deploy", var.subdomain]))
   policy = data.aws_iam_policy_document.deploy_policy.json
 }
 

--- a/route53.tf
+++ b/route53.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "website_primary" {
   } : {}
 
   zone_id = data.terraform_remote_state.dns.outputs.zone_id
-  name    = "www.${var.subdomain}"
+  name    = join(".", compact(["www", var.subdomain]))
   type    = each.value
 
   allow_overwrite = var.allow_dns_overwrite

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "web_bucket" {
-  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
-  bucket = "trons-website-web-${replace(var.subdomain, ".", "-")}"
+  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI
+  // (e.g. bucket.s3.amazonaws.com) so replace them
+  bucket = join("-", compact(["trons-website-web", replace(var.subdomain, ".", "-")]))
 
   website {
     index_document = "index.html"
@@ -61,12 +62,11 @@ resource "aws_s3_bucket_policy" "web_bucket_policy" {
 }
 
 resource "aws_s3_bucket" "redirect_bucket" {
-  // The bucket name must exactly match the DNS name
-  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
-  bucket = "${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
+  // The bucket name must exactly match the DNS name for static web hosting
+  bucket = join(".", compact([var.subdomain, trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")]))
 
   website {
-    redirect_all_requests_to = "https://www.${var.subdomain}.${trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")}"
+    redirect_all_requests_to = join(".", compact(["https://www", var.subdomain, trimsuffix(data.terraform_remote_state.dns.outputs.fqdn, ".")]))
   }
 
   logging {
@@ -101,8 +101,9 @@ resource "aws_s3_bucket_policy" "redirect_bucket_policy" {
 }
 
 resource "aws_s3_bucket" "log_bucket" {
-  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI (e.g. bucket.s3.amazonaws.com)
-  bucket = "trons-website-log-${replace(var.subdomain, ".", "-")}"
+  // The HTTPS certificate will not match bucket names with periods when using the virtual-hosted–style URI
+  // (e.g. bucket.s3.amazonaws.com) so replace them
+  bucket = join("-", compact(["trons-website-log", replace(var.subdomain, ".", "-")]))
 
   server_side_encryption_configuration {
     rule {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "subdomain" {
   type        = string
-  description = "The subdomain the website is available at"
+  description = "The subdomain the website is available at, may be empty"
 }
 
 variable "environment" {


### PR DESCRIPTION
Attempted to deploy production infrastructure, promptly got the following
```
Terraform v0.13.0
Initializing plugins and modules...
aws_acm_certificate.website_primary_certificate: Creating...
aws_iam_user.deploy_user: Creating...
aws_s3_bucket.log_bucket: Creating...
aws_dynamodb_table.lock_table: Creating...
aws_iam_user.deploy_user: Creation complete after 0s [id=svc_website-deploy-]
aws_dynamodb_table.lock_table: Creation complete after 8s [id=trons-website-lock-]

Error: Error requesting certificate: ValidationException: 1 validation error detected: Value 'www..intimitrons.ca' at 'domainName' failed to satisfy constraint: Member must satisfy regular expression pattern: ^(\*\.)?(((?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9])\.)+((?!-)[A-Za-z0-9-]{1,62}[A-Za-z0-9])$
	status code: 400, request id: 8005a4b3-4755-4b80-8189-1c604e1de00a



Error: Error creating S3 bucket: InvalidBucketName: The specified bucket is not valid.
	status code: 400, request id: 46763DDF530545ED, host id: UCm4ec8ksis6TYmN/kxmlyW8zz6FVLu8RvcWNDcvzJisxyD+eDSOb2b7Qp73om39LkZmQpcPkKU=
```

- Update all usages of the `subdomain` variable to account for it being empty

See https://github.com/intimitrons4604/website/issues/108